### PR TITLE
More typo fixes

### DIFF
--- a/examples/Calther/README.md
+++ b/examples/Calther/README.md
@@ -1,5 +1,5 @@
 # Calther
-This example displays a calender along with weather and todo list.
+This example displays a calendar along with weather and todo list.
 Todo list can be synced from [Taiga](https://www.taiga.io) or [Todoist](https://todoist.com) and weather from [Openweathermap](https://www.openweathermap.org)
 
 <img src="Calther.png" width="500" alt="Calther image">

--- a/src/ui/date_time/date_time.cpp
+++ b/src/ui/date_time/date_time.cpp
@@ -113,7 +113,7 @@ void PaperdinkUIDateClass::display_last_updated_time_style1_center(GxEPD2_GFX& d
 	display.print(time_str);
 }
 
-void PaperdinkUIDateClass::display_calender(GxEPD2_GFX& display, uint16_t x, uint16_t y)
+void PaperdinkUIDateClass::display_calendar(GxEPD2_GFX& display, uint16_t x, uint16_t y)
 {
 	int16_t xt, yt;
 	uint16_t wt, ht;

--- a/src/ui/date_time/date_time.h
+++ b/src/ui/date_time/date_time.h
@@ -27,7 +27,7 @@ class PaperdinkUIDateClass : public PaperdinkUIBaseClass
         void display_day_date_style1_center(GxEPD2_GFX& display, uint16_t x, uint16_t y, uint16_t w);
         void display_day_date_style2_center(GxEPD2_GFX& display, uint16_t x, uint16_t y, uint16_t w);
         void display_last_updated_time_style1_center(GxEPD2_GFX& display, uint16_t x, uint16_t y, uint16_t w);
-        void display_calender(GxEPD2_GFX& display, uint16_t x, uint16_t y);
+        void display_calendar(GxEPD2_GFX& display, uint16_t x, uint16_t y);
 };
 
 extern PaperdinkUIDateClass Paperdink_Date;


### PR DESCRIPTION
Went through the code on the entire repo and corrected all "calender" --> "calendar" errors.