### PR TITLE
Rename dependency ArduinoJSON to ArduinoJson

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Requires GxEPD2, Adafruit_GFX, ArduinoJSON, Json Streaming Parser
 category=Display
 url=https://github.com/paperdink/PaperdInk-Library
 architectures=*
-depends=Adafruit GFX Library, GxEPD2, ArduinoJSON, Json Streaming Parser
+depends=Adafruit GFX Library, GxEPD2, ArduinoJson, Json Streaming Parser


### PR DESCRIPTION
This naming mismatch prevented the library from installing in the Arduino IDE.

Fixes #11 