### PR TITLE
Quote example fixes to tags option

### DIFF
--- a/examples/Quotes/Quotes.ino
+++ b/examples/Quotes/Quotes.ino
@@ -59,7 +59,7 @@ void setup()
 	fetch_quote();
 	display_quote(Paperdink.epd);
 
-    /* Send data to display for the update */ 
+    /* Send data to display for the update */
     Paperdink.epd.display();
 
     DEBUG.println("Turning off everything");
@@ -88,7 +88,7 @@ char author_string[MAX_AUTHOR_LENGTH];
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 #define MAX_QUOTE_LENGTH_STR TOSTRING(MAX_QUOTE_LENGTH)
-const char* url = "https://api.quotable.io/random?maxLength="MAX_QUOTE_LENGTH_STR "&tags=";
+const char *url = "https://api.quotable.io/random?maxLength=" MAX_QUOTE_LENGTH_STR "&tags=" QUOTE_TAGS;
 quoteListener quote_listener;
 
 static const char* cert = "-----BEGIN CERTIFICATE-----\n" \
@@ -127,7 +127,7 @@ int8_t fetch_quote()
 {
     int httpCode, ret = 0;
     String payload;
-    
+
     WiFiClientSecure *client = new WiFiClientSecure;
     client->setCACert(cert);
 
@@ -148,13 +148,13 @@ int8_t fetch_quote()
              * Option 1: ArduinoJSON (https://github.com/bblanchon/ArduinoJson)
              * If the data is small, ArduinoJSON can be used
              * which reserves memory and deserializes the incoming JSON data.
-             * 
+             *
              * Option 2: JSON Streaming Parser (https://github.com/squix78/json-streaming-parser)
              * If the data is large, JSON Streaming Parser can be used
              * which does not reserve memory at once. It reserves small chunks of memory
              * and the user can store only what is required.
              */
-            
+
             /* Option 1: ArduinoJSON */
             DynamicJsonDocument json(50 * 1024);
             DeserializationError error = deserializeJson(json, https.getStream());
@@ -168,7 +168,7 @@ int8_t fetch_quote()
                 JsonObject root = json.as<JsonObject>();
                 strncpy(quote_string, root["content"], MAX_QUOTE_LENGTH);
                 Serial.printf("Quote: %s\r\n", quote_string);
-                
+
                 strncpy(author_string, root["author"], MAX_AUTHOR_LENGTH);
                 Serial.printf("Author: %s\r\n", author_string);
             }
@@ -186,7 +186,7 @@ int8_t fetch_quote()
     }
 
     DEBUG.printf("[HTTP] COMPLETED \r\n");
-    
+
     delete client;
     return ret;
 }

--- a/examples/Quotes/README.md
+++ b/examples/Quotes/README.md
@@ -1,14 +1,17 @@
 # Quotes
+
 This example displays quotes fetched from [quotable](https://github.com/lukePeavey/quotable).
 
 <img src="Quotes.png" width="500" alt="Quotes image">
 
 ### Device wake-up
-The refresh can be controlled by the the following two lines. (Only un-comment one of the lines.)
-- Line 1: For lower current consumption, it is possible to wake-up only after a specific period of time defined by the variable `sleep_time`.
-- Line 2: For better control, it is possible to configure a button to trigger a wake-up in addition to a specific time period, but this leads to slightly higer current usage.
 
-```
+The refresh can be controlled by the the following two lines. (Only un-comment one of the lines.)
+
+- Line 1: For lower current consumption, it is possible to wake-up only after a specific period of time defined by the variable `sleep_time`.
+- Line 2: For better control, it is possible to configure a button to trigger a wake-up in addition to a specific time period, but this leads to slightly higher current usage.
+
+```c
   /* Update after sleep_time microsecond or when button 1 is pressed. */
   // Paperdink.deep_sleep_timer_wakeup(sleep_time*S_TO_uS_FACTOR); // Consumes lower current
   Paperdink.deep_sleep_timer_button_wakeup(sleep_time*S_TO_uS_FACTOR, BUTTON_1_PIN); // Consumes higher current
@@ -22,7 +25,7 @@ Update the `config.h` file with configuration details.
 You don't really need to change anything other than selecting paperd.ink device, WiFi details and Time zone.
 Other configuration is provided to make it easy to change font.
 
-```
+```c
 /* CONFIGURATION
  * Uncomment only one of the below #define statements
  * based on the paperd.ink device you have
@@ -46,12 +49,16 @@ Other configuration is provided to make it easy to change font.
  */
 #define UPDATES_PER_DAY 4
 
-/* Comma separated quote tags. See https://api.quotable.io/tags */
-#define QUOTE_TAGS "" // Empty means all quotes
+/* Quote tags (categories). For options, see https://api.quotable.io/tags */
+#define QUOTE_TAGS "" // Empty means include all quote categories
+// | separator -> OR multiple categories
+//#define QUOTE_TAGS "technology|film|future|famous-quotes|science"
+// comma separator -> AND multiple categories (may result in 0 hits)
+//#define QUOTE_TAGS "business,change"
 
 /* Configuration below this is if you want to change the font.
  * Each font size is different, hence tuning the margins and line height
- * is required. Additionally, smaller fonts can accomadate longer quotes.
+ * is required. Additionally, smaller fonts can accommodate longer quotes.
  */
 #define QUOTE_FONT &Roboto_Regular12pt7b
 #define AUTHOR_FONT &Gobold_Thin9pt7b

--- a/examples/Quotes/config.h
+++ b/examples/Quotes/config.h
@@ -25,8 +25,12 @@
  */
 #define UPDATES_PER_DAY 4
 
-/* Comma separated quote tags. See https://api.quotable.io/tags */
-#define QUOTE_TAGS "" // Empty means all quotes
+/* Quote tags (categories). For options, see https://api.quotable.io/tags */
+#define QUOTE_TAGS "" // Empty means include all quote categories
+// | separator -> OR multiple categories
+//#define QUOTE_TAGS "technology|film|future|famous-quotes|science"
+// comma separator -> AND multiple categories (may result in 0 hits)
+//#define QUOTE_TAGS "business,change"
 
 /* Configuration below this is if you want to change the font.
  * Each font size is different, hence tuning the margins and line height

--- a/examples/Quotes/config.h
+++ b/examples/Quotes/config.h
@@ -34,7 +34,7 @@
 
 /* Configuration below this is if you want to change the font.
  * Each font size is different, hence tuning the margins and line height
- * is required. Additionally, smaller fonts can accomadate longer quotes.
+ * is required. Additionally, smaller fonts can accommodate longer quotes.
  */
 #define QUOTE_FONT &Roboto_Regular12pt7b
 #define AUTHOR_FONT &Gobold_Thin9pt7b


### PR DESCRIPTION
I noticed that the tags were not being sent to the quotable API (fixed). Also improved the documentation and comments to explain how this option can be used, and fixed some spelling typos.