### PR TITLE
Use human readable time zones in examples

### DIFF
--- a/examples/Calther/README.md
+++ b/examples/Calther/README.md
@@ -55,7 +55,7 @@ Update the `config.h` file with configuration details
 #define PASSWORD "*****" // Wifi Network password
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Calther/config.h
+++ b/examples/Calther/config.h
@@ -13,7 +13,7 @@
 #define PASSWORD "*****" // Wifi Network password
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Crypto_Tracker/README.md
+++ b/examples/Crypto_Tracker/README.md
@@ -37,7 +37,7 @@ Update the `config.h` file with configuration details
 #define PASSWORD "*****" // Wifi Network password
 
 // Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 // Number of times to update starting 12am
 // 1 = Updates every 24 hours

--- a/examples/Crypto_Tracker/config.h
+++ b/examples/Crypto_Tracker/config.h
@@ -12,7 +12,7 @@
 #define PASSWORD "*****" // Wifi Network password
 
 // Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 // Number of times to update starting 12am
 // 1 = Updates every 24 hours

--- a/examples/Quotes/README.md
+++ b/examples/Quotes/README.md
@@ -37,7 +37,7 @@ Other configuration is provided to make it easy to change font.
 #define PASSWORD "*****" // Wifi Network password
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Quotes/config.h
+++ b/examples/Quotes/config.h
@@ -13,7 +13,7 @@
 #define PASSWORD "*****" // Wifi Network password
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Wave/README.md
+++ b/examples/Wave/README.md
@@ -84,7 +84,7 @@ Update the `config.h` file with configuration details
 #define TAIGA_PROJECT_NAME      "*****" // Taiga project name
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Wave/config.h
+++ b/examples/Wave/config.h
@@ -37,7 +37,7 @@
 #define TAIGA_PROJECT_NAME      "*****" // Taiga project name
 
 /* Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv */
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 /* Number of times to update starting 12am
  * 1 = Updates every 24 hours

--- a/examples/Youtube_Stats/README.md
+++ b/examples/Youtube_Stats/README.md
@@ -27,7 +27,7 @@ Update the `config.h` file with configuration details
 #define PASSWORD "*****" // Wifi Network password
 
 // Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 // Number of times to update starting 12am
 // 1 = Updates every 24 hours

--- a/examples/Youtube_Stats/config.h
+++ b/examples/Youtube_Stats/config.h
@@ -12,7 +12,7 @@
 #define PASSWORD "*****" // Wifi Network password
 
 // Time zone from list https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
-#define TIME_ZONE "PST8PDT,M3.2.0,M11.1.0"
+#define TIME_ZONE "America/Los_Angeles"
 
 // Number of times to update starting 12am
 // 1 = Updates every 24 hours


### PR DESCRIPTION
The time zone in the examples all use the complex `PST8PDT,M3.2.0,M11.1.0` version for Los Angeles. Nothing wrong with that but the more human readable `America/Los_Angeles` works as well. In other words: we could simply use the first column in the referenced [CSV file](https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv) instead of the second.